### PR TITLE
Case Insensitivity Feature for Mini Crossword Time Parser

### DIFF
--- a/app/src/main/java/ppp/stats/parser/MiniCrosswordTimeParser.java
+++ b/app/src/main/java/ppp/stats/parser/MiniCrosswordTimeParser.java
@@ -10,7 +10,7 @@ import ppp.stats.models.IMessage;
 import ppp.stats.models.ITextChannel.Type;
 
 public class MiniCrosswordTimeParser implements IParser {
-    private static Pattern miniTimeReport = Pattern.compile("[0-9]?[0-9]:[0-5][0-9] mini");
+    private static Pattern miniTimeReport = Pattern.compile("[0-9]?[0-9]:[0-5][0-9] (?i)mini");
     private static Pattern miniTime = Pattern.compile("[0-9]?[0-9]:[0-5][0-9]");
 
     private Integer getTime(String msg) {

--- a/app/src/test/java/ppp/stats/parser/MiniCrosswordTimeParserTest.java
+++ b/app/src/test/java/ppp/stats/parser/MiniCrosswordTimeParserTest.java
@@ -17,6 +17,8 @@ public class MiniCrosswordTimeParserTest {
 
         Hashtable<String, Integer> stringPositives = new Hashtable<>();
         stringPositives.put("0:34 mini", 34);
+        stringPositives.put("0:37 MINI", 37);
+        stringPositives.put("4:05 mInI", 245);
         stringPositives.put("2:30 mini", 150);
         stringPositives.put("12:07 mini", 727);
 


### PR DESCRIPTION
Added case insensitivity pattern modifier for the mini time parser. Added test cases to the unit test of the parser. Everything passed on my machine.